### PR TITLE
Add Dependabot update configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Summary:
- Add Dependabot configuration for npm package updates.
- Add Dependabot configuration for GitHub Actions updates.
- Leave existing release workflows and dependency versions unchanged.

Validation:
- npm ci
- npm run lint

Notes:
- npm run test:firefox still fails on the available local Node v24.14.1 runtime with ERR_OSSL_EVP_UNSUPPORTED from the legacy webpack build path.
- CI is intentionally not added in this PR because the full extension validation currently needs an explicit legacy Node baseline or a separate modernization decision.