### PR TITLE
Add Node 16 CI baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  browser-extension:
+    name: Browser extension
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '16'
+          cache: npm
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test:firefox


### PR DESCRIPTION
## Summary
- Add a minimal GitHub Actions CI workflow for the browser extension.
- Run the existing install, lint, and Firefox package lint scripts on Node 16.

## Validation
- Local Node 16.20.2: npm ci passed.
- Local Node 16.20.2: npm run lint passed.
- Local Node 16.20.2: npm run test:firefox passed with existing webpack/web-ext warnings.