### PR TITLE
Revert nextrelease action v2 bump

### DIFF
--- a/.github/workflows/nextrelease.yml
+++ b/.github/workflows/nextrelease.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: '16'
         registry-url: 'https://registry.npmjs.org'
-    - uses: dropseed/nextrelease@v2
+    - uses: dropseed/nextrelease@v1
       with:
         prepare_cmd: |
           sed -i -e "s/v$LAST_VERSION/v$NEXT_VERSION/g" README.md


### PR DESCRIPTION
Restores dropseed/nextrelease to v1 after the v2 bump failed in the release workflow with duplicate Git authorization headers. Keeps the checkout and setup-node action updates.