### PR TITLE
Fix AP title case import for v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^5.0.0",
         "@mui/lab": "^5.0.0-alpha.47",
         "@mui/material": "^5.0.0",
-        "ap-style-title-case": "^1.1.2",
+        "ap-style-title-case": "^2.0.0",
         "base64util": "^2.1.0",
         "debounce": "^1.2.1",
         "esrever": "^0.2.0",
@@ -3237,9 +3237,9 @@
       "dev": true
     },
     "node_modules/ap-style-title-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ap-style-title-case/-/ap-style-title-case-1.1.2.tgz",
-      "integrity": "sha512-8k5jYIf7b+glU3f16eEw5RLdyhXjVWkLYy7XDYSw77a4CUUfGge5c9M/2Obbft5AhZD3RTkCbf3/LAVguLFMfQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ap-style-title-case/-/ap-style-title-case-2.0.0.tgz",
+      "integrity": "sha512-8vCoCer8ZTXjvCK+JQLU0YW0EWI+70lyP9Q33mafLG0VRT7UY1BHoDq7WzaQYwzh9t+eG94tEJuVHrEDcRP1Fg=="
     },
     "node_modules/archive-type": {
       "version": "4.0.0",
@@ -17074,9 +17074,9 @@
       "dev": true
     },
     "ap-style-title-case": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ap-style-title-case/-/ap-style-title-case-1.1.2.tgz",
-      "integrity": "sha512-8k5jYIf7b+glU3f16eEw5RLdyhXjVWkLYy7XDYSw77a4CUUfGge5c9M/2Obbft5AhZD3RTkCbf3/LAVguLFMfQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ap-style-title-case/-/ap-style-title-case-2.0.0.tgz",
+      "integrity": "sha512-8vCoCer8ZTXjvCK+JQLU0YW0EWI+70lyP9Q33mafLG0VRT7UY1BHoDq7WzaQYwzh9t+eG94tEJuVHrEDcRP1Fg=="
     },
     "archive-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@mui/icons-material": "^5.0.0",
     "@mui/lab": "^5.0.0-alpha.47",
     "@mui/material": "^5.0.0",
-    "ap-style-title-case": "^1.1.2",
+    "ap-style-title-case": "^2.0.0",
     "base64util": "^2.1.0",
     "debounce": "^1.2.1",
     "esrever": "^0.2.0",

--- a/utilities/ConvertToTitleCaseAPStyle.js
+++ b/utilities/ConvertToTitleCaseAPStyle.js
@@ -1,4 +1,4 @@
-import apStyleTitleCase from "ap-style-title-case";
+import { apStyleTitleCase } from "ap-style-title-case";
 
 export default (text) => apStyleTitleCase(text, { keepSpaces: true });
 


### PR DESCRIPTION
## Summary
- upgrade `ap-style-title-case` from 1.1.2 to 2.0.0
- switch the AP-style title case utility to v2's named ESM export

## Why
`ap-style-title-case` v2 removes the default CommonJS export and exposes `apStyleTitleCase` as a named ESM export. Keeping the old default import compiles with a webpack warning but leaves the browser bundle calling a missing default export at runtime.

## Validation
- `nvm use 16.20.2; npm ci`
- `nvm use 16.20.2; npm test`
- smoke check: v2 named import returns `The Old Man and the Sea` and `Hello: a Tale of Two Cities`